### PR TITLE
Replace references to gateway-experiments with jupyter-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Gateway Provisioners
 
-[![Build Status](https://github.com/gateway-experiments/gateway_provisioners/actions/workflows/build.yml/badge.svg?query=branch%3Amain++)](https://github.com/gateway-experiments/gateway_provisioners/actions/workflows/build.yml/badge.svg?query=branch%3Amain++)
+[![Build Status](https://github.com/jupyter-server/gateway_provisioners/actions/workflows/build.yml/badge.svg?query=branch%3Amain++)](https://github.com/jupyter-server/gateway_provisioners/actions/workflows/build.yml/badge.svg?query=branch%3Amain++)
 [![Documentation Status](https://readthedocs.org/projects/gateway_provisioners/badge/?version=latest)](https://gateway-provisioners.readthedocs.io/en/latest/?badge=latest)
-
-**NOTE: This repository is experimental and undergoing frequent changes!**
 
 Gateway Provisioners provides [kernel provisioners](https://jupyter-client.readthedocs.io/en/latest/provisioning.html)
 that interact with kernels launched into resource-managed clusters or otherwise run remotely from the launching server.
 This functionality derives from [Jupyter Enterprise Gateway's](https://github.com/jupyter-server/enterprise_gateway)
-_process proxy_ architecture. However, unlike \[process proxies\]
-(https://jupyter-enterprise-gateway.readthedocs.io/en/latest/contributors/system-architecture.html#process-proxy),
+_process proxy_ architecture. However, unlike [process proxies](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/contributors/system-architecture.html#process-proxy),
 you do not need to use a gateway server to use these provisioners - although, in certain cases,
 it is recommended (for example when the launching server does not reside within the same network as the launched kernel).
 
@@ -19,7 +16,7 @@ installed:
 - `KubernetesProvisioner` - Kernels (residing in images) are launched as pods within a Kubernetes cluster
   - `pip install gateway_provisioners[k8s]`
 - `DockerSwarmProvisioner` - Kernels (residing in images) are launched as containers within a DockerSwarm cluster
-- `DockerProvisioner` - Kernels (residing in images) are launched as containers
+- `DockerProvisioner` - Kernels (residing in images) are launched as containers on the local server
   - `pip install gateway_provisioners[docker]`
 - `YarnProvisioner` - Kernels are launched into a Hadoop YARN cluster (primarily Spark)
   - `pip install gateway_provisioners[yarn]`
@@ -35,15 +32,17 @@ files into docker images relative to the desired provisioner:
 - `jupyter-ssh-spec` - for building kernel specifications relative to the `DistributedProvisioner`
 - `jupyter-image-bootstrap` - for injecting bootstrap support when building kernel-based images
 
-**NOTE: The container-based provisioners (`KubernetesProvisioner`, `DockerSwarmProvisioner`, and `DockerProvisioner`)
-require that the hosting server also be running within the same environment/network. As a result, these
-provisioners may be better suited for use by a Gateway Server (Kernel Gateway or Enterprise Gateway) to
-not require the Notebook/Lab server to be in a container.**
+**Note:** The container-based provisioners (`KubernetesProvisioner`, `DockerSwarmProvisioner`, and `DockerProvisioner`)
+require that the hosting server also be running within the same environment/network. As a result, these provisioners
+may be better suited for use by a Gateway Server (e.g., [Jupyter Kernel Gateway](https://github.com/jupyter-server/kernel_gateway))
+so as to not require the Notebook/Lab server also be deployed in a container.
+
+______________________________________________________________________
 
 ## Installation
 
-Detailed installation instructions are located in the
-[Operators Guide](https://gateway-provisioners.readthedocs.io/en/latest/operators/installing-gp.html)
+Detailed deployment instructions are located in the
+[Operators Guide](https://gateway-provisioners.readthedocs.io/en/latest/operators/index.html)
 of the project docs. Here's a quick start using `pip`:
 
 ```bash
@@ -51,17 +50,17 @@ of the project docs. Here's a quick start using `pip`:
 pip install --upgrade gateway-provisioners
 
 # options for the command-line utilities can be viewed using '--help-all'
-jupyter k8s-spec install --help-all
+jupyter yarn-spec install --help-all
 
-# run it with default options
-jupyter k8s-spec install
+# run it with default options to install a Python-based kernelspec for Hadoop Yarn
+jupyter yarn-spec install
 ```
 
 ## Contributing
 
 The [Contribution page](https://gateway-provisioners.readthedocs.io/en/latest/contributors/contrib.html) includes
 information about how to contribute to Gateway Provisioners. We encourage you to explore the other topics in our
-[Contributor's Guide](https://gateway-provisioners.readthedocs.io/en/latest/contributors/index.html)
+[Contributors Guide](https://gateway-provisioners.readthedocs.io/en/latest/contributors/index.html)
 like how to [set up a development environment](https://gateway-provisioners.readthedocs.io/en/latest/contributors/devinstall.html),
-gaining an understanding of the [system architecture](https://gateway-provisioners.readthedocs.io/en/latest/contributors/system-architecture.html),
-and taking a look at the [API documentation](https://gateway-provisioners.readthedocs.io/en/latest/api/modules.html), among other thigns.
+or gaining an understanding of the [system architecture](https://gateway-provisioners.readthedocs.io/en/latest/contributors/system-architecture.html),
+among other things.

--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -1,7 +1,7 @@
 # Development Workflow
 
 Here are instructions for setting up a development environment for the
-[Gateway Provisioners](https://github.com/gateway-experiments/gateway_provisioners)
+[Gateway Provisioners](https://github.com/jupyter-server/gateway_provisioners)
 project. It also includes common steps in the developer workflow such as building Gateway Provisioners,
 running tests, building docs, etc.
 
@@ -36,13 +36,13 @@ mkdir -p ~/projects
 cd ~/projects
 
 # clone this repo
-git clone https://github.com/gateway-experiments/gateway_provisioners.git
+git clone https://github.com/jupyter-server/gateway_provisioners.git
 ```
 
 ## Make
 
 Gateway Provisioner's build environment is centered around `make` and the
-corresponding [`Makefile`](https://github.com/gateway-experiments/gateway_provisioners/blob/main/Makefile).
+corresponding [`Makefile`](https://github.com/jupyter-server/gateway_provisioners/blob/main/Makefile).
 
 Entering `make` with no parameters yields the following:
 
@@ -63,27 +63,44 @@ test                           Run tests with the currently active Python versio
 A typical sequence of commands might include the following:
 
 - Clean the current build environment
-  ```bash
+
+  ```text
   make clean
   ```
+
 - Apply changes and ensure updates pass lint
-  ```bash
+
+  ```text
   make lint
   ```
+
 - If lint-related errors are present, they can usually be fixed using `lint-fix`
-  ```bash
+
+  ```text
   make lint-fix
   ```
+
 - Build the distribution
-  ```bash
+
+  ```text
   make dist
   ```
+
 - Run tests via Makefile (`pytest -v`)
-  ```bash
+
+  ```text
   make test
   ```
+
+- Build the docs
+
+  ```text
+  make docs
+  ```
+
 - Build the images
-  ```bash
+
+  ```text
   make images
   ```
 

--- a/docs/source/contributors/related-resources.md
+++ b/docs/source/contributors/related-resources.md
@@ -2,10 +2,10 @@
 
 Here are some resources related to the Gateway Provisioners project.
 
-- [Jupyter.org](https://jupyter.org)
-- [Jupyter Server Team Compass](https://github.com/jupyter-server/team-compass#jupyter-server-team-compass)
-- [Jupyter Calendar - Community Meetings](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings)
-- [Jupyter Community Discourse Forum](https://discourse.jupyter.org/)
+- [Jupyter.org](https://jupyter.org) - the official Jupyter organization website.
+- [Jupyter Server Team Compass](https://github.com/jupyter-server/team-compass#jupyter-server-team-compass) - all things related to the Jupyter Server organization.
+- [Jupyter Calendar - Community Meetings](https://docs.jupyter.org/en/latest/community/content-community.html#jupyter-community-meetings) - the set of Jupyter-related meetings - all are welcome!
+- [Jupyter Community Discourse Forum](https://discourse.jupyter.org/) - the public forum for Jupyter-related questions, discussions, and announcements.
 - [Jupyter Enterprise Gateway Github Repo](https://github.com/jupyter-server/enterprise_gateway) - the source code for Enterprise Gateway - which supports remote kernels using Process Proxies. It's 4.0 release will support kernel provisioners and process proxy support will go away.
 - [Jupyter Kernel Gateway Github Repo](https://github.com/jupyter-server/kernel_gateway) - the source code for Kernel Gateway - which immediately supports kernel provisioners by virtue of using the base `KernelManager` class.
 - [Jupyter Server Github Repo](https://github.com/jupyter-server/jupyter_server) - the source code for the Jupyter Server.

--- a/docs/source/contributors/system-architecture.md
+++ b/docs/source/contributors/system-architecture.md
@@ -9,7 +9,7 @@ Gateway provisioner classes derive from the abstract base class
 [`KernelProvisionerBase`](https://github.com/jupyter/jupyter_client/blob/adff6b1d4389c885ee7ff4764fc5ffad6fcbe53f/jupyter_client/provisioning/provisioner_base.py#L17) -
 which defines abstract methods for managing the kernel process's lifecycle. There are two immediate subclasses of
 `KernelProvisionerBase` - [`LocalProvisioner`](https://github.com/jupyter/jupyter_client/blob/adff6b1d4389c885ee7ff4764fc5ffad6fcbe53f/jupyter_client/provisioning/local_provisioner.py#L16)
-(provided by `juptyer_client`) and [`RemoteProvisionerBase`](https://github.com/gateway-experiments/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/remote_provisioner.py#L75) -
+(provided by `juptyer_client`) and [`RemoteProvisionerBase`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/remote_provisioner.py#L75) -
 the base class of all Gateway Provisioners' provisioners.
 
 `LocalProvisioner` is essentially a pass-through to the current implementation. Kernel specifications that do not contain
@@ -18,17 +18,17 @@ a `process_proxy` stanza will use `LocalProvisioner`.
 `RemoteProvisionerBase` is an abstract base class representing remote kernel processes. Currently, there are five
 built-in subclasses of `RemoteProvisionerBase` ...
 
-- [`DistributedProvisioner`](https://github.com/gateway-experiments/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/distributed.py#L65) -
+- [`DistributedProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/distributed.py#L65) -
   largely a proof of concept class, `DistributedProvisioner` is responsible for the launch
   and management of kernels distributed across an explicitly defined set of hosts using ssh. Hosts are determined
   via a round-robin algorithm (that we should make pluggable someday).
-- [`YarnProvisioner`](https://github.com/gateway-experiments/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/yarn.py#L42) -
+- [`YarnProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/yarn.py#L42) -
   is responsible for the discovery and management of kernels hosted as Hadoop YARN applications within a managed cluster.
-- [`KubernetesProvisioner`](https://github.com/gateway-experiments/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/k8s.py#L56) -
+- [`KubernetesProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/k8s.py#L56) -
   is responsible for the discovery and management of kernels hosted within a Kubernetes cluster.
-- [`DockerSwarmProvisioner`](https://github.com/gateway-experiments/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/docker_swarm.py#L33) -
+- [`DockerSwarmProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/docker_swarm.py#L33) -
   is responsible for the discovery and management of kernels hosted within a Docker Swarm cluster.
-- [`DockerProvisioner`](https://github.com/gateway-experiments/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/docker_swarm.py#L159) -
+- [`DockerProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/docker_swarm.py#L159) -
   is responsible for the discovery and management of kernels hosted within Docker configuration.
 
 ```{attention}

--- a/docs/source/developers/custom-images.md
+++ b/docs/source/developers/custom-images.md
@@ -38,7 +38,7 @@ needs to support.
 
 #### Bootstrap-kernel.sh
 
-Gateway Provisioners provides a single [bootstrap-kernel.sh](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh)
+Gateway Provisioners provides a single [bootstrap-kernel.sh](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh)
 script that handles the three kernel languages supported out of the box - Python, R, and Scala. When a kernel image
 is started by Gateway Provisioners, parameters used within the bootstrap-kernel.sh script are conveyed via environment
 variables. The bootstrap script is then responsible for validating and converting those parameters to meaningful
@@ -46,7 +46,7 @@ arguments to the appropriate launcher.
 
 #### Kernel Launcher
 
-The kernel launcher, as discussed [here](kernel-launcher.md) does a number of things. In particular, it creates
+The kernel launcher, as discussed [here](kernel-launcher.md), does a number of things. In particular, it creates
 the connection ports and conveys that connection information back to the host application via the socket identified
 by the response address parameter. Although not a requirement for container-based usage, it is recommended that the
 launcher be written in the same language as the kernel. (This is more of a requirement when used in applications
@@ -96,7 +96,7 @@ during the build of the docker image.
 ```{tip}
 All kernel images produced by Gateway Provisioners derive from `jupyter/docker-stacks-foundation` - which is the root
 image for all docker-stacks images.  You can see how our kernel images are built looking at
-[`kernel-image/Dockerfile`](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/docker/kernel-image/Dockerfile).
+[`kernel-image/Dockerfile`](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/docker/kernel-image/Dockerfile).
 ```
 
 ## Deploying Your Custom Kernel Image
@@ -112,7 +112,7 @@ respectively.  Invoke the appropriate script by adding the `--image-name` parame
 custom kernel image.  For example, if your custom image is named `acme/data-sci-py:2.0` and you are targeting
 Kubernetes, issue:
 
-```bash
+```dockerfile
 RUN jupyter k8s-spec install --image-name acme/data-sci-py:2.0 --kernel-name data_sci_py --display-name 'Data Science 2.0'
 ```
 

--- a/docs/source/developers/dev-remote-provisioner.md
+++ b/docs/source/developers/dev-remote-provisioner.md
@@ -42,11 +42,11 @@ You will likely need to provide implementations for `launch_process()`, `poll()`
 reused.
 
 For example, if your provisioner is going to service remote kernels, you should consider deriving your implementation
-from the [`RemoteProvisionerBase` class](https://github.com/gateway-experiments/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/remote_provisioner.py#L75).
+from the [`RemoteProvisionerBase` class](https://github.com/jupyter-server/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/remote_provisioner.py#L75).
 If this is the case, then you'll need to implement `confirm_remote_startup()`.
 
 Likewise, if your process proxy is based on containers, you should consider deriving your implementation from
-the [`ContainerProvisionerBase` class](https://github.com/gateway-experiments/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/container.py#L32).
+the [`ContainerProvisionerBase` class](https://github.com/jupyter-server/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/container.py#L32).
 If this is the case, then you'll need to implement `get_container_status()` and `terminate_container_resources()`
 rather than `confirm_remote_startup()`, etc.
 

--- a/docs/source/developers/kernel-launcher.md
+++ b/docs/source/developers/kernel-launcher.md
@@ -2,7 +2,7 @@
 
 A new implementation for a [_kernel launcher_](../contributors/system-architecture.md#kernel-launchers) becomes
 necessary when you want to introduce another kind of kernel to an existing configuration. Out of the box, Gateway
-Provisioners provides [kernel launchers](https://github.com/gateway-experiments/gateway_provisioners/tree/main/gateway_provisioners/kernel-launchers)
+Provisioners provides [kernel launchers](https://github.com/jupyter-server/gateway_provisioners/tree/main/gateway_provisioners/kernel-launchers)
 that support the IPython kernel ([and subclasses thereof](#invoking-subclasses-of-ipykernelkernelbasekernel)), the
 Apache Toree scala kernel, and the R kernel - IRKernel. There are other "language-agnostic kernel launchers"
 provided by Remote Provisioners, but those are used in container environments to start the container or pod where
@@ -27,7 +27,7 @@ The four tasks of a kernel launcher are:
 If your target kernel exists, then there is probably support for creating ZeroMQ ports. If this proves difficult,
 you may be able to take a _hybrid approach_ where the connection information, encryption and listener portion of
 things is implemented in Python, while invocation takes place in the native language. This is how the
-[R kernel-launcher](https://github.com/gateway-experiments/gateway_provisioners/tree/main/gateway_provisioners/kernel-launchers/R/scripts)
+[R kernel-launcher](https://github.com/jupyter-server/gateway_provisioners/tree/main/gateway_provisioners/kernel-launchers/R/scripts)
 support is implemented.
 
 When creating the connection information, your kernel launcher should handle the possibility that the `--port-range`
@@ -37,7 +37,7 @@ The port used between the host application and the kernel launcher, known as the
 adhere to the port range. It is not required that this port be ZeroMQ (and is not a ZMQ port in existing
 implementations).
 
-Here's where the Python (and R) [ports are selected](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L163-L180),
+Here's where the Python (and R) [ports are selected](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L163-L180),
 adhering to any port range restrictions.
 
 ## Encrypting the Connection Information
@@ -47,18 +47,18 @@ this, the connection information, including the communication port, is encrypted
 16-byte key. The AES key is then encrypted using the public key specified in the `public_key` parameter. These
 two fields (the AES-encrypted payload and the public-key-encrypted AES key) are then included into a JSON
 structure that also include the launcher's version information and base64 encoded. Here's such an example
-from the [Python (and R) kernel launchers](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L77-L100).
+from the [Python (and R) kernel launchers](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L77-L100).
 
-The payload is then [sent back on a socket](https://github.com/gateway-experiments/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L102-L139)
+The payload is then [sent back on a socket](https://github.com/jupyter-server/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L102-L139)
 identified by the `--response-address` option.
 
 ## Invoking the Target Kernel
 
-For the R kernel launcher, the kernel is started using [`IRKernel::main()`](https://github.com/gateway-experiments/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/R/scripts/launch_IRkernel.R#L232)
+For the R kernel launcher, the kernel is started using [`IRKernel::main()`](https://github.com/jupyter-server/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/R/scripts/launch_IRkernel.R#L232)
 after the `SparkContext` is initialized based on the `spark-context-initialization-mode` parameter.
 
 The scala kernel launcher works similarly in that the Apache Toree kernel provides an
-["entrypoint" to start the kernel](https://github.com/gateway-experiments/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala#L312),
+["entrypoint" to start the kernel](https://github.com/jupyter-server/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala#L312),
 however, because the Toree kernel initializes a `SparkContext` itself, the need to do so is conveyed directly to the kernel.
 
 For the Python kernel launcher, it creates a namespace instance that contains the `SparkContext` information, if
@@ -144,7 +144,7 @@ its final cleanup. The form of this request is `{"shutdown": 1}`. This is what i
 listening on the communication socket and to exit.
 
 Here's an example from the Python (and R) server listener code of
-[handling host-initiated requests](https://github.com/gateway-experiments/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L231-L245).
+[handling host-initiated requests](https://github.com/jupyter-server/gateway_provisioners/blob/9de8af8a361aa779f8eb4d10585c0d917bb3731f/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py#L231-L245).
 
 ## Other Parameters
 

--- a/docs/source/developers/kernel-specification.md
+++ b/docs/source/developers/kernel-specification.md
@@ -56,7 +56,7 @@ Here's an example from a generated kernel specification for Spark running in a H
 }
 ```
 
-where [`run.sh`](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/kernel-specs/yarn_spark_python/bin/run.sh)
+where [`run.sh`](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/kernel-specs/yarn_spark_python/bin/run.sh)
 issues `spark-submit` specifying the kernel launcher as the "application":
 
 ```bash
@@ -70,7 +70,7 @@ eval exec \
 ```
 
 For container-based environments, the `argv` may instead reference a script that is meant to create the container pod
-(for Kubernetes). For these, we use a [template file](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2)
+(for Kubernetes). For these, we use a [template file](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2)
 that operators can adjust to meet the needs of their environment. Here's how that `kernel.json` looks:
 
 ```json

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,13 +28,7 @@ becoming familiar with the roles in which you are most impacted.  These roles ar
 4. `Contributors <contributors/index.html>`_: people contributing directly to the Gateway Provisioners project.
 
 If you find gaps in our documentation, please open an issue (or better yet, a pull request) on the
-Gateway Provisioners `Github repo <https://github.com/gateway-experiments/gateway_provisioners>`_.
-
-.. note::
-   The following pages are still in transition from the `Jupyter Enterprise Gateway repository
-   <https://github.com/jupyter-server/enterprise_gateway>`_.  As a result, you will find information that pertains
-   to Enterprise Gateway, but really has no application relative to Gateway Provisioners.
-   Please bear with us in these busy (and exciting) times!
+Gateway Provisioners `Github repo <https://github.com/jupyter-server/gateway_provisioners>`_.
 
 
 Table of Contents

--- a/docs/source/operators/config-security.md
+++ b/docs/source/operators/config-security.md
@@ -52,7 +52,7 @@ authorization list the failure was generated.
 Failures stemming from _inclusion_ in the `unauthorized_users` list will include text similar to
 the following:
 
-```
+```text
 User 'bob' is not authorized to start kernel 'Spark - Python (YARN Mode)'. Ensure
 KERNEL_USERNAME is set to an appropriate value and retry the request.
 ```
@@ -60,7 +60,7 @@ KERNEL_USERNAME is set to an appropriate value and retry the request.
 Failures stemming from _exclusion_ from a non-empty `authorized_users` list will include text
 similar to the following:
 
-```
+```text
 User 'bob' is not in the set of users authorized to start kernel 'Spark - Python (YARN Mode)'. Ensure
 KERNEL_USERNAME is set to an appropriate value and retry the request.
 ```

--- a/docs/source/operators/deploy-distributed.md
+++ b/docs/source/operators/deploy-distributed.md
@@ -26,7 +26,7 @@ configured.
 
 - `SPARK_HOME` must point to the Apache Spark installation path
 
-```
+```text
 SPARK_HOME:/usr/hdp/current/spark2-client  # For HDP distribution
 ```
 
@@ -70,14 +70,14 @@ jupyter ssh-spec install
 
 which produces the following output...
 
-```
+```text
 [I 2023-02-08 16:21:50.254 SshSpecInstaller] Installing kernel specification for 'Python SSH'
 [I 2023-02-08 16:21:50.485 SshSpecInstaller] Installed kernelspec ssh_python in /usr/local/share/jupyter/kernels/ssh_python
 ```
 
 and the following set of files and directories:
 
-```
+```text
 /usr/local/share/jupyter/kernels/ssh_python
 kernel.json logo-64x64.png
 
@@ -121,7 +121,7 @@ For shared environments (typical in Gateway server deployments) we recommend ins
 into a shared folder like `/usr/local/share/jupyter/kernels` (which is the default).  This is the location in
 which they reside within container images and where many of the document references assume they'll be located.
 
-Alternate locatiions can be specified via option `--user` (which places the set of files within the invoking user's
+Alternate locations can be specified via option `--user` (which places the set of files within the invoking user's
 home directory structure) or option `--sys-prefix` (which places the set of files within the active python
 environment's directory structure).
 ```
@@ -164,7 +164,6 @@ following (this one is relative to the Python kernel using defaulted parameters)
     }
   }
 }
-
 ```
 
 The `metadata` and `argv` entries for each kernel specification should be nearly identical and
@@ -178,7 +177,7 @@ You should also check the same kinds of environment and path settings in the cor
 
 The following is produced using `juptyer ssh-spec install --help` and displays the complete set of command-line options.
 
-```
+```text
 Creates a Jupyter kernel specification for use within a cluster of hosts via
 SSH.
 

--- a/docs/source/operators/deploy-docker.md
+++ b/docs/source/operators/deploy-docker.md
@@ -29,14 +29,14 @@ RUN jupyter docker-spec install
 
 which produces the following output...
 
-```
+```text
 [I 2023-02-15 14:10:16.892 DockerSpecInstaller] Installing kernel specification for 'Docker Python'
 [I 2023-02-15 14:10:17.306 DockerSpecInstaller] Installed kernelspec docker_python in /usr/local/share/jupyter/kernels/docker_python
 ```
 
 and the following set of files and directories:
 
-```
+```text
 /usr/local/share/jupyter/kernels/docker_python
 kernel.json logo-64x64.png
 

--- a/docs/source/operators/deploy-kubernetes.md
+++ b/docs/source/operators/deploy-kubernetes.md
@@ -21,14 +21,14 @@ RUN jupyter k8s-spec install
 
 which produces the following output...
 
-```
+```text
 [I 2023-02-16 10:39:37.538 K8sSpecInstaller] Installing kernel specification for 'Kubernetes Python'
 [I 2023-02-16 10:39:37.948 K8sSpecInstaller] Installed kernelspec k8s_python in /usr/local/share/jupyter/kernels/k8s_python
 ```
 
 and the following set of files and directories:
 
-```
+```text
 /usr/local/share/jupyter/kernels/docker_python
 kernel.json logo-64x64.png
 

--- a/docs/source/operators/deploy-yarn-cluster.md
+++ b/docs/source/operators/deploy-yarn-cluster.md
@@ -30,15 +30,15 @@ to facilitate the integration between Apache Spark and Hadoop YARN components:
 
 - `SPARK_HOME` must point to the Apache Spark installation path
 
-```
-SPARK_HOME:/usr/hdp/current/spark2-client  # For HDP distribution
+```bash
+export SPARK_HOME=/usr/hdp/current/spark2-client  # For HDP distribution
 ```
 
 - GP_YARN_ENDPOINT: Must point to the YARN resource manager endpoint if the host application is
   remote from the YARN cluster
 
-```
-GP_YARN_ENDPOINT=http://${YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster
+```bash
+export GP_YARN_ENDPOINT=http://${YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster
 ```
 
 ```{note}
@@ -51,8 +51,8 @@ YARN cluster is configured for high availability.
 If server is remote from the YARN cluster (i.e., no `HADOOP_CONF_DIR`) and the YARN cluster is
 configured for high availability, then the alternate endpoint should also be specified...
 
-```
-GP_ALT_YARN_ENDPOINT=http://${ALT_YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
+```bash
+export GP_ALT_YARN_ENDPOINT=http://${ALT_YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
 ```
 
 ## Generating Kernel Specifications
@@ -67,14 +67,14 @@ jupyter yarn-spec install
 
 which produces the following output...
 
-```
+```text
 [I 2023-02-08 09:48:48.685 YarnSpecInstaller] Installing kernel specification for 'Spark Python (YARN Cluster)'
 [I 2023-02-08 09:48:49.048 YarnSpecInstaller] Installed kernelspec yarn_spark_python in /usr/local/share/jupyter/kernels/yarn_spark_python
 ```
 
 and the following set of files and directories:
 
-```
+```text
 /usr/local/share/jupyter/kernels/yarn_spark_python
 kernel.json logo-64x64.png
 
@@ -112,11 +112,11 @@ toree kernel (`toree-assembly-TOREE_VERSION.jar`)
 ```
 
 ```{tip}
-For shared environments (typical in Gateway server deploymetns) we recommend installing kernel specifications
+For shared environments (typical in Gateway server deployments) we recommend installing kernel specifications
 into a shared folder like `/usr/local/share/jupyter/kernels` (which is the default).  This is the location in
 which they reside within container images and where many of the document references assume they'll be located.
 
-Alternate locatiions can be specified via option `--user` (which places the set of files within the invoking user's
+Alternate locations can be specified via option `--user` (which places the set of files within the invoking user's
 home directory structure) or option `--sys-prefix` (which places the set of files within the active python
 environment's directory structure).
 ```

--- a/docs/source/operators/installing-kernels-container.md
+++ b/docs/source/operators/installing-kernels-container.md
@@ -11,7 +11,7 @@ in the applicable sections for [Kubernetes](deploy-kubernetes.md) and [Docker/Do
 follows are instructions for how to build the kernel-based image.
 
 ```{tip}
-Gateway Provisioners provides a [Makefile](https://github.com/gateway-experiments/gateway_provisioners/blob/main/Makefile)
+Gateway Provisioners provides a [Makefile](https://github.com/jupyter-server/gateway_provisioners/blob/main/Makefile)
 for building the various kernel images.  The instructions that follow will reference `make` targets to accomplish
 these tasks.
 ```
@@ -25,8 +25,8 @@ from which the target image is derived.
 ### Spark Base Image
 
 Spark-based images will be built upon the `elyra/gp-spark-base` image, whose
-[`Dockerfile`](https://github.com/gateway-experiments/gateway_provisioners/tree/main/gateway_provisioners/docker/gp-spark-base/Dockerfile) is located in
-[`gateway_provisioners/docker/gp-spark-base`](https://github.com/gateway-experiments/gateway_provisioners/tree/main/gateway_provisioners/docker/gp-spark-base).
+[`Dockerfile`](https://github.com/jupyter-server/gateway_provisioners/tree/main/gateway_provisioners/docker/gp-spark-base/Dockerfile) is located in
+[`gateway_provisioners/docker/gp-spark-base`](https://github.com/jupyter-server/gateway_provisioners/tree/main/gateway_provisioners/docker/gp-spark-base).
 This image builds on `jupyter/docker-stacks-foundation:2022-11-15` by installing Spark.  However, that base can also be
 substituted via the build argument `BASE_CONTAINER`.
 
@@ -53,9 +53,9 @@ As with `DOCKER_ORG` and `TAG`, each of the above build arguments can be specifi
 
 ### Kernel Images
 
-The [`Dockerfile`](https://github.com/gateway-experiments/gateway_provisioners/blob/main/gateway_provisioners/docker/kernel-image/Dockerfile)
+The [`Dockerfile`](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/docker/kernel-image/Dockerfile)
 used to create a kernel image representing any of the supported kernels is located in
-[`gateway_provisioners/docker/kernel-image`](https://github.com/gateway-experiments/gateway_provisioners/tree/main/gateway_provisioners/docker/kernel-image).
+[`gateway_provisioners/docker/kernel-image`](https://github.com/jupyter-server/gateway_provisioners/tree/main/gateway_provisioners/docker/kernel-image).
 
 This is a [_multi-stage build_](https://docs.docker.com/build/building/multi-stage/) Dockerfile whose build options are
 driven by [`docker build` arguments](https://docs.docker.com/engine/reference/builder/#arg).  There are three primary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ file = "LICENSE.md"
 [project.urls]
 Homepage = "https://jupyter.org"
 Documentation = "https://gateway-provisioners.readthedocs.io/"
-Source = "https://github.com/gateway-experiments/gateway_provisioners"
-Tracker = "https://github.com/gateway-experiments/gateway_provisioners/issues"
+Source = "https://github.com/jupyter-server/gateway_provisioners"
+Tracker = "https://github.com/jupyter-server/gateway_provisioners/issues"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Apply touch-ups to docs.  In particular, replace references to `gateway-experiments` with `jupyter-server` as part of the repo transfer to Jupyter Server.