### PR TITLE
Create hatch build env with make-related scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,12 @@ repos:
       - id: mdformat
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.225
+    rev: v0.0.249
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-# extract version from gateway_provisioners/_version.py - override using `make VERSION=foo target`
-VERSION?=$(shell grep ^__version__ gateway_provisioners/_version.py | awk '{print $$3}' | sed s'/"//g')
+# extract version from gateway_provisioners/_version.py - don't allow override since python -m build
+# only uses value stored in _version.py
+VERSION=$(shell grep ^__version__ gateway_provisioners/_version.py | awk '{print $$3}' | sed s'/"//g')
 
-# When building images, where to get the remote-provisioners package: "local" (wheel) or "release" (pip)
+# When building images, where to get the gateway-provisioners package: "local" (wheel) or "release" (pip)
 PACKAGE_SOURCE?=local
 
 # Docker attributes - hub organization and tag.  Modify accordingly
@@ -104,8 +105,8 @@ wheel: gateway_provisioners/kernel-launchers/scala/lib $(WHEEL_FILE)
 $(WHEEL_FILE): $(WHEEL_FILES)
 	python -m build --wheel
 
-install: clean wheel ## Install the package to the active Python's site-packages
-	pip uninstall -y remote-provisioners
+install:  ## Install the built package to the active Python's site-packages
+	pip uninstall -y gateway-provisioners
 	pip install dist/gateway_provisioners-*.whl
 
 gateway_provisioners/kernel-launchers/scala/lib: $(TOREE_LAUNCHER_FILES)

--- a/gateway_provisioners/cli/base_app.py
+++ b/gateway_provisioners/cli/base_app.py
@@ -522,7 +522,6 @@ class BaseSpecApp(RemoteProvisionerConfigMixin, BaseApp):
 
 
 class BaseSpecSparkApp(BaseSpecApp):
-
     spark_home = Unicode(
         os.getenv("SPARK_HOME", "/opt/spark"),
         config=True,

--- a/gateway_provisioners/cli/image_bootstrapapp.py
+++ b/gateway_provisioners/cli/image_bootstrapapp.py
@@ -86,7 +86,6 @@ jupyter-image-bootstrap install --languages=Python --languages=Scala
 
     @overrides
     def detect_missing_extras(self):
-
         for lang in self.languages:
             if lang.lower() == SCALA:
                 self._detect_missing_toree_jar()

--- a/gateway_provisioners/config_mixin.py
+++ b/gateway_provisioners/config_mixin.py
@@ -16,7 +16,6 @@ ssh_port = int(os.getenv("GP_SSH_PORT", "22"))
 
 
 class RemoteProvisionerConfigMixin(Configurable):
-
     _log_formatter_cls = LogFormatter  # traitlet default is LevelFormatter
 
     @default("log_format")

--- a/gateway_provisioners/docker_swarm.py
+++ b/gateway_provisioners/docker_swarm.py
@@ -225,7 +225,6 @@ class DockerProvisioner(ContainerProvisionerBase):
             try:
                 container.remove(force=True)  # Container still exists, attempt forced removal
             except Exception as err:
-
                 self.log.debug(
                     f"Container termination for container: {container.name} raised exception: {err}"
                 )

--- a/gateway_provisioners/k8s.py
+++ b/gateway_provisioners/k8s.py
@@ -243,7 +243,6 @@ class KubernetesProvisioner(ContainerProvisionerBase):
         return pod_name
 
     def _determine_kernel_namespace(self, **kwargs):
-
         # Since we need the service account name regardless of whether we're creating the namespace or not,
         # get it now.
         service_account_name = KubernetesProvisioner._determine_kernel_service_account_name(

--- a/gateway_provisioners/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/gateway_provisioners/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -143,7 +143,7 @@ def launch_kubernetes_kernel(
             with open(spark_opts_out, "w+") as soo_fd:
                 soo_fd.write(additional_spark_opts)
         else:  # If no spark_opts_out was specified, print to stdout in case this is an old caller
-            print(additional_spark_opts)  # noqa: T201
+            print(additional_spark_opts)
 
 
 def _get_spark_resources(pod_template: dict) -> str:

--- a/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py
+++ b/gateway_provisioners/kernel-launchers/shared/scripts/server_listener.py
@@ -61,7 +61,6 @@ class ServerListener:
         self.comm_socket: socket | None = None
 
     def build_connection_file(self) -> None:
-
         ports: list = self._select_ports(5)
         write_connection_file(
             fname=self.conn_filename,

--- a/gateway_provisioners/remote_provisioner.py
+++ b/gateway_provisioners/remote_provisioner.py
@@ -145,7 +145,6 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
 
     @overrides
     async def launch_kernel(self, cmd: List[str], **kwargs: Any) -> KernelConnectionInfo:
-
         launch_kwargs = RemoteProvisionerBase._scrub_kwargs(kwargs)
         self.local_proc = gp_launch_kernel(cmd, **launch_kwargs)
         self.pid = self.local_proc.pid
@@ -251,7 +250,6 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
 
     @overrides
     def _finalize_env(self, env: Dict[str, str]) -> None:
-
         # add the applicable kernel_id and language to the env dict
         env["KERNEL_ID"] = self.kernel_id
 
@@ -351,7 +349,6 @@ class RemoteProvisionerBase(RemoteProvisionerConfigMixin, KernelProvisionerBase)
         # active, even after the kernel has terminated, leading to less than graceful terminations.
 
         if self.comm_port > 0:
-
             try:
                 await self._send_listener_request({"shutdown": 1}, shutdown_socket=True)
                 self.log.debug("Shutdown request sent to listener via gateway communication port.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ email = "jupyter@googlegroups.org"
 file = "README.md"
 content-type = "text/markdown"
 
-
 [project.license]
 file = "LICENSE.md"
 
@@ -86,6 +85,11 @@ dev = [
   "build",
   "twine",
 ]
+lint = [
+  "black[jupyter]==23.1.0",
+  "mdformat>0.7",
+  "ruff==0.0.249",
+]
 yarn = [
     "yarn-api-client"
 ]
@@ -118,6 +122,14 @@ validate-bump = false
 [tool.hatch.build]
 artifacts = ["gateway_provisioners/kernel-launchers/scala/lib"]
 
+[tool.hatch.envs.build]
+features = ["dev"]
+[tool.hatch.envs.build.scripts]
+clean = "make clean"
+lint = "make lint"
+dist = "make dist"
+all = "make clean lint dist install"
+
 [tool.hatch.envs.docs]
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]
@@ -131,12 +143,7 @@ test = "python -m pytest -vv {args}"
 nowarn = "test -W default {args}"
 
 [tool.hatch.envs.lint]
-detached = true
-dependencies = [
-  "black[jupyter]==22.12.0",
-  "mdformat>0.7",
-  "ruff==0.0.225",
-]
+features = ["lint"]
 [tool.hatch.envs.lint.scripts]
 style = [
   "ruff {args:.}",

--- a/tests/mocks/yarn_client.py
+++ b/tests/mocks/yarn_client.py
@@ -39,7 +39,6 @@ class MockResponse:
 
 
 class MockResourceManager:
-
     CLUSTER_CONTAINER_MEMORY = 1024 * 1024 * 1024  # 1GB
 
     def __init__(self, **kwargs):

--- a/tests/test_docker_provisioners.py
+++ b/tests/test_docker_provisioners.py
@@ -14,7 +14,6 @@ from validators import TEST_USER, ValidatorBase
     [("docker", {"KERNEL_USERNAME": TEST_USER}), ("docker-swarm", {"KERNEL_USERNAME": TEST_USER})],
 )
 async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, name, seed_env):
-
     kernel_id = str(uuid4())
     validator = ValidatorBase.create_instance(
         name, seed_env, kernel_id=kernel_id, response_manager=response_manager

--- a/tests/test_k8s_provisioners.py
+++ b/tests/test_k8s_provisioners.py
@@ -11,7 +11,6 @@ from validators import TEST_USER, K8sValidator
 
 @pytest.mark.parametrize("seed_env", [{"KERNEL_USERNAME": TEST_USER}])
 async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, seed_env):
-
     name = "kubernetes"
     kernel_id = str(uuid4())
     validator = K8sValidator.create_instance(

--- a/tests/test_yarn_provisioners.py
+++ b/tests/test_yarn_provisioners.py
@@ -17,7 +17,6 @@ YARN_SEED_ENV = {
 
 @pytest.mark.parametrize("seed_env", [YARN_SEED_ENV])
 async def test_lifecycle(init_api_mocks, response_manager, get_provisioner, seed_env):
-
     name = "yarn"
     kernel_id = str(uuid4())
     validator = YarnValidator.create_instance(


### PR DESCRIPTION
This pull request introduces a hatch env name `build` in which various _scripts_ are defined that map to various `make` commands.  I'm not sure what _value_ this PR adds, but it does trigger the operations to occur within a hatch environment. 

This also updates the versions of `ruff` and `black` and includes the lint-related fixes corresponding to those updates.