### PR TITLE
Fix relative link formatting in documentation to be consistent 

### DIFF
--- a/docs/source/contributors/devinstall.md
+++ b/docs/source/contributors/devinstall.md
@@ -106,6 +106,6 @@ A typical sequence of commands might include the following:
   ```
 
 ```{seealso}
-See [Kernel-image Dockerfiles](operators/installing-kernels-container.md#kernel-image-dockerfiles) in our
+See [Kernel-image Dockerfiles](../operators/installing-kernels-container.md#kernel-image-dockerfiles) in our
 Operators Guide for additional information regarding image Dockerfiles, build arguments, etc.
 ```

--- a/docs/source/contributors/system-architecture.md
+++ b/docs/source/contributors/system-architecture.md
@@ -218,7 +218,7 @@ For a current enumeration of which system-level configuration values can be over
 see [Per-kernel overrides](../operators/config-kernel-override.md).
 
 ```{seealso}
-For an overview of all configuration options see [Configuration Options](operators/config-file.md#configuration-options)
+For an overview of all configuration options see [Configuration Options](../operators/config-file.md#configuration-options)
 in our Operators Guide.
 ```
 


### PR DESCRIPTION
In opening #67, the [test failure](https://github.com/jupyter-server/gateway_provisioners/actions/runs/4326980294/jobs/7555069162) alerted me to a new issue. I think the latest release of [`myst-parser`](https://github.com/executablebooks/MyST-Parser/releases/tag/v0.19.0) was causing some new behavior that revealed these relative link warnings. That being said, the links work just fine both with and without this change. This basically just improves consistency with how other relative links are already handled (see other examples using relative paths in the `devinstall.md` file).