### PR TITLE
Add link to SparkOperatorProvisioner class definition

### DIFF
--- a/docs/source/contributors/system-architecture.md
+++ b/docs/source/contributors/system-architecture.md
@@ -26,7 +26,7 @@ built-in subclasses of `RemoteProvisionerBase`:
   is responsible for the discovery and management of kernels hosted as Hadoop YARN applications within a managed cluster.
 - [`KubernetesProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/k8s.py#L56) -
   is responsible for the discovery and management of kernels hosted within a Kubernetes cluster.
-- `SparkOperatorProvisioner` -
+- [`SparkOperatorProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/4c82a803614e8b26803d4a25c18683e3e5f4ec06/gateway_provisioners/spark_operator.py#L8) -
   is responsible for the discovery and management of kernels hosted within a Kubernetes cluster that are provisioned via
   the Custom Resource Definition (CRD) `SparkApplication`.
 - [`DockerSwarmProvisioner`](https://github.com/jupyter-server/gateway_provisioners/blob/d400f6f48de61823c596e4f774a42b01b17e6887/gateway_provisioners/docker_swarm.py#L33) -


### PR DESCRIPTION
I couldn't add this in #80 since the file wasn't committed yet. 

Here's a screen shot of the link being "alive":
![Screenshot 2023-04-20 at 3 07 52 PM](https://user-images.githubusercontent.com/22599560/233497918-80a9a476-7de1-4180-bcb1-ded7272139b5.png)
