### PR TITLE
Fix kernel-class-name option

### DIFF
--- a/gateway_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh
+++ b/gateway_provisioners/kernel-launchers/bootstrap/bootstrap-kernel.sh
@@ -19,7 +19,7 @@ launch_python_kernel() {
   then
     kernel_class_option=""
   else
-    kernel_class_option="--kernel_class_name ${KERNEL_CLASS_NAME}"
+    kernel_class_option="--kernel-class-name ${KERNEL_CLASS_NAME}"
   fi
 
 	set -x


### PR DESCRIPTION
Thank you for creating awesome product.

While verifying the gateway provisioner in my team, we encountered the following error and will fix it.
 If necessary, we will create an issue to link to it.

```terminal
+ python /usr/local/bin/kernel-launchers/python/scripts/launch_ipykernel.py --kernel-id 525a7083-ab49-4b63-8687-9546dd6192d9 --port-range 0..0 --response-address ${correct_response_address} --public-key ${correct_public_key} --spark-context-initialization-mode none --kernel_class_name ipykernel.ipkernel.IPythonKernel
usage: launch_ipykernel.py [-h] [--response-address [<ip>:<port>]]
                           [--kernel-id [KERNEL_ID]]
                           [--public-key [PUBLIC_KEY]]
                           [--port-range [<lowerPort>..<upperPort>]]
                           [--spark-context-initialization-mode [INIT_MODE]]
                           [--cluster-type [CLUSTER_TYPE]]
                           [--kernel-class-name [KERNEL_CLASS_NAME]]
launch_ipykernel.py: error: unrecognized arguments: --kernel_class_name ipykernel.ipkernel.IPythonKernel
```