### PR TITLE
Fix: reset assigned_host to empty string to avoid NoneType IP during kernel restart

### DIFF
--- a/gateway_provisioners/yarn.py
+++ b/gateway_provisioners/yarn.py
@@ -240,8 +240,9 @@ HADOOP_CONFIG_DIR to determine the active resource manager.
             self.local_proc.wait()
             self.local_proc = None
 
-        # reset application id to force new query - handles kernel restarts/interrupts
+        # reset application id and assigned host to force new query - handles kernel restarts/interrupts
         self.application_id = None
+        self.assigned_host = ""
 
         # for cleanup, we should call the superclass last
         await super().cleanup(restart=restart)


### PR DESCRIPTION
When restarting a YARN provisioned kernel, the process fails because the connection info is not properly updated. This happens due to the condition `if assigned_host == self.assigned_host` in [yarn.py#L510](https://github.com/jupyter-server/gateway_provisioners/blob/main/gateway_provisioners/yarn.py#L510) evaluating to `False` during the restart, which causes it to skip updating the connection info. The `assigned_host` and `assigned_ip` don't get updated during the restart which leads to the following error:
```
traitlets.traitlets.TraitError: The 'ip' trait of an ServerKernelManager instance expected a unicode string, not the NoneType None.
```